### PR TITLE
Quickstart: Fix broken link

### DIFF
--- a/get-started/quickstart.md
+++ b/get-started/quickstart.md
@@ -18,7 +18,7 @@ Select your use case:
 * [Anomaly Detection](quickstart.md#anomaly-detection)
 * [Natural Language Processing](quickstart.md#natural-language-processing)
 * [Association Rules Mining](quickstart.md#association-rules-mining)
-* [Time Series (beta)](quickstart.md#time-series-beta)
+* [Time Series (beta)](quickstart.md#time-series)
 
 ## Classification
 


### PR DESCRIPTION
The header-link to the time series section did not work. I changed it from `time-series-beta` to `time-series`.